### PR TITLE
Updated OEM display names case and sort order in picker UI

### DIFF
--- a/SmartcarAuth/OEM/OEM.swift
+++ b/SmartcarAuth/OEM/OEM.swift
@@ -13,32 +13,32 @@ import UIKit
 
 public class OEM {
     static let oemDictionary: [OEMName: OEMConfig] =
-        [.acura: OEMConfig(color: "#020202", displayName: "acura"),
-         .audi: OEMConfig(color: "#000000", displayName: "audi"),
-         .bmw: OEMConfig(color: "#2E9BDA", displayName: "bmw"),
-         .bmwConnected: OEMConfig(color: "#2E9BDA", displayName: "bmw-connected"),
-         .buick: OEMConfig(color: "#333333", displayName: "buick"),
-         .cadillac: OEMConfig(color: "#941711", displayName: "cadillac"),
-         .chevrolet: OEMConfig(color: "#042F6B", displayName: "chevrolet"),
-         .chrysler: OEMConfig(color: "#231F20", displayName: "chrysler"),
-         .dodge: OEMConfig(color: "#000000", displayName: "dodge"),
-         .ford: OEMConfig(color: "#003399", displayName: "ford"),
-         .fiat: OEMConfig(color: "#B50536", displayName: "fiat"),
-         .gmc: OEMConfig(color: "#CC0033", displayName: "gmc"),
-         .honda: OEMConfig(color: "#DA251D", displayName: "honda"),
-         .hyundai: OEMConfig(color: "#00287A", displayName: "hyundai"),
-         .infiniti: OEMConfig(color: "#1F1F1F", displayName: "infiniti"),
-         .jeep: OEMConfig(color: "#374B00", displayName: "jeep"),
-         .kia: OEMConfig(color: "#C4172C", displayName: "kia"),
-         .landrover: OEMConfig(color: "#005A2B", displayName: "landrover"),
-         .lexus: OEMConfig(color: "#5B7F95", displayName: "lexus"),
-         .nissan: OEMConfig(color: "#C71444", displayName: "nissan"),
-         .nissanev: OEMConfig(color: "#C71444", displayName: "nissanev"),
-         .ram: OEMConfig(color: "#000000", displayName: "ram"),
-         .tesla: OEMConfig(color: "#CC0000", displayName: "tesla"),
-         .volkswagen: OEMConfig(color: "#000000", displayName: "volkswagen"),
-         .volvo: OEMConfig(color: "#000F60", displayName: "volvo"),
-         .mercedes: OEMConfig(color: "#222222", displayName: "mercedes"),
+        [.acura: OEMConfig(color: "#020202", displayName: "Acura"),
+         .audi: OEMConfig(color: "#000000", displayName: "Audi"),
+         .bmw: OEMConfig(color: "#2E9BDA", displayName: "BMW"),
+         .bmwConnected: OEMConfig(color: "#2E9BDA", displayName: "BMW Connected"),
+         .buick: OEMConfig(color: "#333333", displayName: "Buick"),
+         .cadillac: OEMConfig(color: "#941711", displayName: "Cadillac"),
+         .chevrolet: OEMConfig(color: "#042F6B", displayName: "Chevrolet"),
+         .chrysler: OEMConfig(color: "#231F20", displayName: "Chrysler"),
+         .dodge: OEMConfig(color: "#000000", displayName: "Dodge"),
+         .ford: OEMConfig(color: "#003399", displayName: "Ford"),
+         .fiat: OEMConfig(color: "#B50536", displayName: "Fiat"),
+         .gmc: OEMConfig(color: "#CC0033", displayName: "GMC"),
+         .honda: OEMConfig(color: "#DA251D", displayName: "Honda"),
+         .hyundai: OEMConfig(color: "#00287A", displayName: "Hyundai"),
+         .infiniti: OEMConfig(color: "#1F1F1F", displayName: "INFINITI"),
+         .jeep: OEMConfig(color: "#374B00", displayName: "Jeep"),
+         .kia: OEMConfig(color: "#C4172C", displayName: "Kia"),
+         .landrover: OEMConfig(color: "#005A2B", displayName: "Land Rover"),
+         .lexus: OEMConfig(color: "#5B7F95", displayName: "Lexus"),
+         .nissan: OEMConfig(color: "#C71444", displayName: "Nissan"),
+         .nissanev: OEMConfig(color: "#C71444", displayName: "Nissan EV"),
+         .ram: OEMConfig(color: "#000000", displayName: "Ram"),
+         .tesla: OEMConfig(color: "#CC0000", displayName: "Tesla"),
+         .volkswagen: OEMConfig(color: "#000000", displayName: "Volkswagen"),
+         .volvo: OEMConfig(color: "#000F60", displayName: "Volvo"),
+         .mercedes: OEMConfig(color: "#222222", displayName: "Mercedes-Benz"),
          .mock: OEMConfig(color: "#495F5D", displayName: "mock")]
     
     /**
@@ -77,4 +77,18 @@ public class OEM {
         return array
     }
     
+}
+
+extension Array where Element == OEMName {
+    /**
+     Return sorted list of contained `OEMName`s by `displayName`, while keeping `mock` at the end
+     */
+    public func sortedByDisplayName() -> [Element] {
+        return sorted(by: { (oem1, oem2) -> Bool in
+            if oem1 == .mock {
+                return false
+            }
+            return OEM.getDisplayName(for: oem1) < OEM.getDisplayName(for: oem2)
+        })
+    }
 }

--- a/SmartcarAuth/UIGenerator/SmartcarAuthPickerGenerator.swift
+++ b/SmartcarAuth/UIGenerator/SmartcarAuthPickerGenerator.swift
@@ -36,7 +36,7 @@ public class SmartcarAuthPickerGenerator: SmartcarAuthUIGenerator, UIPickerViewD
     
     public init(sdk: SmartcarAuth, viewController: UIViewController, oemList: [OEMName] = OEM.getDefaultOEMList()){
         super.init(sdk: sdk, viewController: viewController)
-        self.oemList = oemList
+        self.oemList = oemList.sortedByDisplayName()
         
         if sdk.request.development {
             self.oemList.append(OEMName.mock)
@@ -159,6 +159,6 @@ public class SmartcarAuthPickerGenerator: SmartcarAuthUIGenerator, UIPickerViewD
     }
     
     public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return OEM.getDisplayName(for: self.oemList[row]).uppercased()
+        return OEM.getDisplayName(for: self.oemList[row])
     }
 }


### PR DESCRIPTION
Hello everyone,

The picker UI currently uses an all-uppercase list of OEMs, this commit fixes it by using the usual case for each OEM display name. It also ensures the list is sorted while keeping mock at the end (though this should not be needed since it should be appended after the list has been sorted).

Thanks for considering