### PR TITLE
Fix scope encoding issues

### DIFF
--- a/SmartcarAuth/SmartcarAuth.swift
+++ b/SmartcarAuth/SmartcarAuth.swift
@@ -94,15 +94,13 @@ public class SmartcarAuth: NSObject {
         }
 
         if !scope.isEmpty {
-            if let scopeString = self.scope.joined(separator: " ").addingPercentEncoding( withAllowedCharacters: .urlQueryAllowed) {
-                queryItems.append(URLQueryItem(name: "scope", value: scopeString))
-            }
-
+            let scopeString = self.scope.joined(separator: " ")
+            queryItems.append(URLQueryItem(name: "scope", value: scopeString))
         }
 
         queryItems.append(URLQueryItem(name: "approval_prompt", value: forcePrompt ? "force" : "auto"))
 
-        if let stateString = state?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+        if let stateString = state {
             queryItems.append(URLQueryItem(name: "state", value: stateString))
         }
 


### PR DESCRIPTION
NSURLQueryItem and NSURLComponents automatically handles percent encoding, there is no need to do it manually. Removing the manual escaping fixes a 400 invalid scope issue when specifying multiple scopes