### PR TITLE
Update SmartcarAuth to use mode=test|live

### DIFF
--- a/SmartcarAuth.podspec
+++ b/SmartcarAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmartcarAuth'
-  s.version          = '2.0.5'
+  s.version          = '2.1.0'
   s.summary          = 'Smartcar Authentication SDK for iOS written in Swift 3.'
 
   s.description      = <<-DESC

--- a/SmartcarAuth/SmartcarAuth.swift
+++ b/SmartcarAuth/SmartcarAuth.swift
@@ -45,7 +45,7 @@ Smartcar Authentication SDK for iOS written in Swift 3.
         - clientId: app client id
         - redirectUri: app redirect uri
         - scope: app oauth scope
-        - testMode: optional, launch the Smartcar auth flow in test mode
+        - testMode: optional, launch the Smartcar auth flow in test mode, defaults to false
         - completion: callback function called upon the completion of the OAuth flow with the error, the auth code, and the state string
     */
     @objc public init(clientId: String, redirectUri: String, scope: [String] = [], testMode: Bool = false, completion: @escaping (Error?, String?, String?) -> Any?) {

--- a/SmartcarAuth/SmartcarAuth.swift
+++ b/SmartcarAuth/SmartcarAuth.swift
@@ -105,7 +105,7 @@ Smartcar Authentication SDK for iOS written in Swift 3.
             queryItems.append(URLQueryItem(name: "state", value: stateString))
         }
         
-        var mode = self.testMode ? "test" : "live";
+        let mode = self.testMode ? "test" : "live";
 
         queryItems.append(URLQueryItem(name: "mode", value: mode))
 

--- a/SmartcarAuth/SmartcarAuth.swift
+++ b/SmartcarAuth/SmartcarAuth.swift
@@ -36,7 +36,7 @@ Smartcar Authentication SDK for iOS written in Swift 3.
     var redirectUri: String
     var scope: [String]
     var completion: (Error?, String?, String?) -> Any?
-    var development: Bool
+    var testMode: Bool
 
     /**
     Constructor for the SmartcarAuth
@@ -45,15 +45,15 @@ Smartcar Authentication SDK for iOS written in Swift 3.
         - clientId: app client id
         - redirectUri: app redirect uri
         - scope: app oauth scope
-        - development: optional, shows the mock OEM for testing, defaults to false
+        - testMode: optional, launch the Smartcar auth flow in test mode
         - completion: callback function called upon the completion of the OAuth flow with the error, the auth code, and the state string
     */
-    @objc public init(clientId: String, redirectUri: String, scope: [String] = [], development: Bool = false, completion: @escaping (Error?, String?, String?) -> Any?) {
+    @objc public init(clientId: String, redirectUri: String, scope: [String] = [], testMode: Bool = false, completion: @escaping (Error?, String?, String?) -> Any?) {
         self.clientId = clientId
         self.redirectUri = redirectUri
         self.scope = scope
         self.completion = completion
-        self.development = development
+        self.testMode = testMode
     }
 
     /**
@@ -104,8 +104,10 @@ Smartcar Authentication SDK for iOS written in Swift 3.
         if let stateString = state {
             queryItems.append(URLQueryItem(name: "state", value: stateString))
         }
+        
+        var mode = self.testMode ? "test" : "live";
 
-        queryItems.append(URLQueryItem(name: "mock", value: String(self.development)))
+        queryItems.append(URLQueryItem(name: "mode", value: mode))
 
         components.queryItems = queryItems
 

--- a/SmartcarAuthTests/SmartcarAuthTests.swift
+++ b/SmartcarAuthTests/SmartcarAuthTests.swift
@@ -26,7 +26,7 @@ class SmartcarAuthTests: XCTestCase {
     
     func testGenerateUrl() {
         
-        let smartcarSdk = SmartcarAuth(clientId: clientId, redirectUri: redirectUri, scope: scope,  development: true, completion: {
+        let smartcarSdk = SmartcarAuth(clientId: clientId, redirectUri: redirectUri, scope: scope,  testMode: true, completion: {
             error, code, state in
             
             fail("Callback should not have been called")
@@ -35,7 +35,7 @@ class SmartcarAuthTests: XCTestCase {
         
         let url = smartcarSdk.generateUrl(state: state, forcePrompt: true)
         
-        expect(url).to(equal("https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=\(self.clientId)&redirect_uri=\(self.redirectUri)&scope=read_vehicle_info%20read_odometer&approval_prompt=force&state=\(self.state)&mock=true"))
+        expect(url).to(equal("https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=\(self.clientId)&redirect_uri=\(self.redirectUri)&scope=read_vehicle_info%20read_odometer&approval_prompt=force&state=\(self.state)&mode=test"))
     }
     
     func testGenerateUrlDefaultValues() {
@@ -48,7 +48,7 @@ class SmartcarAuthTests: XCTestCase {
         
         let url = smartcarSdk.generateUrl()
         
-        expect(url).to(equal("https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=\(self.clientId)&redirect_uri=\(self.redirectUri)&approval_prompt=auto&mock=false"))
+        expect(url).to(equal("https://connect.smartcar.com/oauth/authorize?response_type=code&client_id=\(self.clientId)&redirect_uri=\(self.redirectUri)&approval_prompt=auto&mode=live"))
     }
     
     func testHandleCallbackNoQueryParameters() {


### PR DESCRIPTION
## Changes
Update SDK to take in a `testMode` boolean parameter that adds `mode=test` (if true) or `mode=live` (if false) to the Smartcar auth URL.