### PR TITLE
Revert testMode flag addition

### DIFF
--- a/SmartcarAuth/SmartcarAuth.swift
+++ b/SmartcarAuth/SmartcarAuth.swift
@@ -45,7 +45,7 @@ Smartcar Authentication SDK for iOS written in Swift 3.
         - clientId: app client id
         - redirectUri: app redirect uri
         - scope: app oauth scope
-        - testMode: optional, launch the Smartcar auth flow in test mode, defaults to false
+        - testMode: optional, launch the Smartcar auth flow in test mode
         - completion: callback function called upon the completion of the OAuth flow with the error, the auth code, and the state string
     */
     @objc public init(clientId: String, redirectUri: String, scope: [String] = [], testMode: Bool = false, completion: @escaping (Error?, String?, String?) -> Any?) {


### PR DESCRIPTION
This reverts commit 65fd0f100b5c8d8315c4d65043f3cd4435d9868e.

## Reasoning
- testMode flag was added as a breaking change in the auth constructor (https://github.com/smartcar/ios-sdk/pull/38). However, testMode should have been added in a way that was backwards compatible with the `development` flag.