### PR TITLE
SDK Reference Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SmartcarAuth is available through [CocoaPods](http://cocoapods.org). To install 
 pod "SmartcarAuth"
 ```
 
-## Authorization
+## Getting Started
 
 First you need to have a global SmartcarAuth object in your AppDelegate to hold the session, in order to continue the authorization flow from the redirect.
 
@@ -36,6 +36,10 @@ Then, initiate the SmartcarAuth object in the UIViewController.
 
 ```swift
 let appDelegate = UIApplication.shared.delegate as! AppDelegate
+
+func completionHandler(err: Error?, code: String?, state: String?) -> Any {
+ // Receive authorization code
+}
 
 appDelegate.smartcar = SmartcarAuth(
   clientId: "afb0b7d3-807f-4c61-9b04-352e91fe3134",
@@ -77,28 +81,28 @@ func application(_ application: UIApplication, open url: URL, options: [UIApplic
 
 ### Class `SmartcarAuth` Constructor
 
-| Parameter | Type | Description |
-| --------- | -------- | ----------- |
-| `clientId` | `String` | **Required** Application client ID obtained from [Smartcar Developer Portal](https://developer.smartcar.com/). |
-| `redirectUri` | `String` | **Required** Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://page`). Read here for more information on [configuration of a custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html). |
-| `scope` | `Array<String>` | **Optional** Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs/api) for a full list of available permissions. If no `scope` variable is provided, all permissions will be requested. |
-| `testMode` | `Bool` | **Optional** Defaults to `false`. Set to `true` to launch the Smartcar auth flow in test mode. |
-| `completion` | `Function` | **Required** Callback function for when the Authorization Flow returns with either an Error or a `code` and the `state`. The function should take in the optional params `func (error: Error?, code: String?, state: String?) -> Any`. The return of the callback function will be returned from `smartcarSdk.launchAuthFlow()`. The completion handler should handle any Errors encountered during the Authorization Flow process and send the `code` to the server-side to retrieve an `accessToken`. If a `state` parameter was provided, then it should be checked to make sure the returned `state` matches the input `state`. |
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `clientId` | `String` | _Required_ | Application client ID obtained from [Smartcar Developer Portal](https://developer.smartcar.com/). |
+| `redirectUri` | `String` | _Required_ | Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://page`). Read here for more information on [configuration of a custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html). |
+| `scope` | `Array<String>` | `[]` | Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs/api) for a full list of available permissions. If the `scope` array is empty, all permissions will be requested. |
+| `testMode` | `Bool` | `false` | Set to `true` to launch the Smartcar auth flow in test mode. |
+| `completion` | `Function` | _Required_ | Callback function for when the Authorization Flow returns with either an Error or a `code` and the `state`. The function should take in the optional params `func (error: Error?, code: String?, state: String?) -> Any`. The return of the callback function will be returned from `smartcarSdk.launchAuthFlow()`. The completion handler should handle any Errors encountered during the Authorization Flow process and send the `code` to the server-side to retrieve an `accessToken`. If a `state` parameter was provided, then it should be checked to make sure the returned `state` matches the input `state`. |
 
-### Method `.launchAuthFlow(state, forcePrompt, vehicleInfo, viewController)`
+### Method `.launchAuthFlow`
 
-| Parameter | Type | Description |
-| --------- | -------- | ----------- |
-| `state` | `String` | **Optional** Defaults to `nil`. An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded. |
-| `forcePrompt` | `Bool` | **Optional** Defaults to `false`. The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past. | 
-| `vehicleInfo` | `VehicleInfo` | **Optional** Defaults to `nil`. Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `state` | `String` | `nil` | An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded. |
+| `forcePrompt` | `Bool` | `false` | The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past. |
+| `vehicleInfo` | `VehicleInfo` | `nil` | Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 
 ### Class `VehicleInfo` Constructor
 
-| Parameter | Type | Description |
-| --------- | -------- | ----------- |
-| `make` | String | **Optional** Defaults to `nil`. Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `make` | String | `nil` | Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ func application(_ application: UIApplication, open url: URL, options: [UIApplic
 ## SDK Reference
 
 For detailed documentation on parameters and available methods, please refer to
-the [SDK Reference](doc/readme.md).
+the [SDK Reference](doc/README.md).
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -36,60 +36,20 @@ Then, initiate the SmartcarAuth object in the UIViewController.
 
 ```swift
 let appDelegate = UIApplication.shared.delegate as! AppDelegate
-appDelegate.smartcar = SmartcarAuth(clientId: clientId, redirectUri: redirectUri, scope: scope, completion: completionHandler)
+
+appDelegate.smartcar = SmartcarAuth(
+  clientId: "afb0b7d3-807f-4c61-9b04-352e91fe3134",
+  redirectUri: "scafb0b7d3-807f-4c61-9b04-352e91fe3134://page",
+  scope: ["read_vin", "read_vehicle_info", "read_odometer"],
+  completion: completionHandler
+)
 let smartcarSdk = appDelegate.smartcarSdk
 
 // initialize authorization flow on the SFSafariViewController
 smartcarSdk.launchAuthFlow(state: state, forcePrompt: false, testMode: false, viewController: viewController)
 ```
 
-### SmartcarAuth Parameters
-
-`clientId`
-
-Application client ID obtained from [Smartcar Developer Portal](https://developer.smartcar.com/).
-
-`redirectUri`
-
-Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered
-in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://oauth2redirect.com/page`).
-
-More information on [configuration of custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html).
-
-`scope` (optional)
-
-Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs) for a full list of available permissions. If no `scope` variable is provided, then Smartcar Authorization Flow will display the full list of permissions granted to the clientId.
-
-`testMode` (optional)
-
-Defaults to `nil`. Set to `true` to launch the Smartcar auth flow in test mode.
-
-`completion`
-
-Callback function for when the Authorization Flow returns with either an Error or a `code` and the `state`. The function should take in the optional params `func (error: Error?, code: String?, state: String?) -> Any`. The return of the callback function will be returned from `smartcarSdk.launchAuthFlow()`. The completion handler should handle any Errors encountered during the Authorization Flow process and send the `code` to the server-side to retrieve an `accessToken`. If a `state` parameter was provided, then it should be checked to make sure the returned `state` matches the input `state`.
-
-### VehicleInfo Parameters
-
-`make` (optional)
-
-Defaults to `nil`. Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation.
-
-### launchAuthFlow Parameters
-
-`state` (optional)
-
-Defaults to `nil`. An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded.
-
-`forcePrompt` (optional)
-
-Defaults to `false`. The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past.
-
-`vehicleInfo` (optional)
-
-Defaults to `nil`. Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation.
-
-
-### Handling the Redirect
+## Handling the Redirect
 
 The authorization response URL is returned to the app via the iOS openURL app delegate method, so you need to pipe this through to the current authorization session
 
@@ -112,6 +72,33 @@ func application(_ application: UIApplication, open url: URL, options: [UIApplic
     return true
 }
 ```
+
+## SDK Reference
+
+### Class `SmartcarAuth` Constructor
+
+| Parameter | Type | Description |
+| --------- | -------- | ----------- |
+| `clientId` | `String` | **Required** Application client ID obtained from [Smartcar Developer Portal](https://developer.smartcar.com/). |
+| `redirectUri` | `String` | **Required** Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://page`). Read here for more information on [configuration of a custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html). |
+| `scope` | `Array<String>` | **Optional** Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs/api) for a full list of available permissions. If no `scope` variable is provided, all permissions will be requested. |
+| `testMode` | `Bool` | **Optional** Defaults to `false`. Set to `true` to launch the Smartcar auth flow in test mode. |
+| `completion` | `Function` | **Required** Callback function for when the Authorization Flow returns with either an Error or a `code` and the `state`. The function should take in the optional params `func (error: Error?, code: String?, state: String?) -> Any`. The return of the callback function will be returned from `smartcarSdk.launchAuthFlow()`. The completion handler should handle any Errors encountered during the Authorization Flow process and send the `code` to the server-side to retrieve an `accessToken`. If a `state` parameter was provided, then it should be checked to make sure the returned `state` matches the input `state`. |
+
+### Method `.launchAuthFlow(state, forcePrompt, vehicleInfo, viewController)`
+
+| Parameter | Type | Description |
+| --------- | -------- | ----------- |
+| `state` | `String` | **Optional** Defaults to `nil`. An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded. |
+| `forcePrompt` | `Bool` | **Optional** Defaults to `false`. The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past. | 
+| `vehicleInfo` | `VehicleInfo` | **Optional** Defaults to `nil`. Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+
+
+### Class `VehicleInfo` Constructor
+
+| Parameter | Type | Description |
+| --------- | -------- | ----------- |
+| `make` | String | **Optional** Defaults to `nil`. Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pod "SmartcarAuth"
 
 ## Getting Started
 
-First you need to have a global SmartcarAuth object in your AppDelegate to hold the session, in order to continue the authorization flow from the redirect.
+First, you need to have a global SmartcarAuth object in your AppDelegate to hold the session, in order to continue the authorization flow from the redirect.
 
 ```swift
 // global variable in the app's AppDelegate

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ appDelegate.smartcar = SmartcarAuth(
   scope: ["read_vin", "read_vehicle_info", "read_odometer"],
   completion: completionHandler
 )
-let smartcarSdk = appDelegate.smartcarSdk
+let smartcar = appDelegate.smartcar
 
 // initialize authorization flow on the SFSafariViewController
-smartcarSdk.launchAuthFlow(state: state, forcePrompt: false, testMode: false, viewController: viewController)
+smartcar.launchAuthFlow(state: state, forcePrompt: false, testMode: false, viewController: viewController)
 ```
 
 ## Handling the Redirect
@@ -79,30 +79,8 @@ func application(_ application: UIApplication, open url: URL, options: [UIApplic
 
 ## SDK Reference
 
-### Class `SmartcarAuth` Constructor
-
-| Parameter | Type | Default | Description |
-| --------- | ---- | ------- | ----------- |
-| `clientId` | `String` | _Required_ | Application client ID obtained from [Smartcar Developer Portal](https://developer.smartcar.com/). |
-| `redirectUri` | `String` | _Required_ | Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://page`). Read here for more information on [configuration of a custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html). |
-| `scope` | `Array<String>` | `[]` | Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs/api) for a full list of available permissions. If the `scope` array is empty, all permissions will be requested. |
-| `testMode` | `Bool` | `false` | Set to `true` to launch the Smartcar auth flow in test mode. |
-| `completion` | `Function` | _Required_ | Callback function for when the Authorization Flow returns with either an Error or a `code` and the `state`. The function should take in the optional params `func (error: Error?, code: String?, state: String?) -> Any`. The return of the callback function will be returned from `smartcarSdk.launchAuthFlow()`. The completion handler should handle any Errors encountered during the Authorization Flow process and send the `code` to the server-side to retrieve an `accessToken`. If a `state` parameter was provided, then it should be checked to make sure the returned `state` matches the input `state`. |
-
-### Method `.launchAuthFlow`
-
-| Parameter | Type | Default | Description |
-| --------- | ---- | ------- | ----------- |
-| `state` | `String` | `nil` | An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded. |
-| `forcePrompt` | `Bool` | `false` | The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past. |
-| `vehicleInfo` | `VehicleInfo` | `nil` | Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
-
-
-### Class `VehicleInfo` Constructor
-
-| Parameter | Type | Default | Description |
-| --------- | ---- | ------- | ----------- |
-| `make` | String | `nil` | Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+For detailed documentation on parameters and available methods, please refer to
+the [SDK Reference](doc/readme.md).
 
 ## Author
 

--- a/SmartcarAuth.podspec
+++ b/SmartcarAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmartcarAuth'
-  s.version          = '2.2.3'
+  s.version          = '2.2.4'
   s.summary          = 'Smartcar Authentication SDK for iOS written in Swift 3.'
 
   s.description      = <<-DESC

--- a/doc/README.md
+++ b/doc/README.md
@@ -74,7 +74,7 @@ smartcar.launchAuthFlow(viewController: self)
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
-| `make` | String | `nil` | Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| `make` | String | `nil` | For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 ### Example
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -26,7 +26,7 @@ Smartcar iOS SDK documentation.
 | `redirectUri` | `String` | _Required_ | Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://page`). Read here for more information on [configuration of a custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html). |
 | `scope` | `Array<String>` | `[]` | Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs/api) for a full list of available permissions. If the `scope` array is empty, all permissions will be requested. |
 | `testMode` | `Bool` | `false` | Set to `true` to launch the Smartcar auth flow in test mode. |
-| `completion` | `Function` | _Required_ | Callback function to be invoked upon completion of the Smartcar Authorization Flow. See the **Completion Handler** section below for details on the function's inputs. |
+| `completion` | `Function` | _Required_ | Callback function to be invoked upon completion of the Smartcar Authorization Flow. See the [Completion Handler](#completion-handler) section below for details on the function's inputs. |
 
 ### Example
 
@@ -43,7 +43,7 @@ let smartcar = SmartcarAuth(
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
-| `error` | `AuthorizationError` | `nil` | This error will be present if there is a failure in the Smartcar Authorization Flow. Normally, this indicates that a vehicle owner pressed "Deny" to grant your application access to their vehicle. |
+| `error` | [`AuthorizationError`](#enum-authorizationerror) | `nil` | This error will be present if there is a failure in the Smartcar Authorization Flow. Normally, this indicates that a vehicle owner pressed "Deny" to grant your application access to their vehicle. |
 | `code` | `String` | `nil` | Received upon successful authorization. This code should be used to exchange with Smartcar for a long lasting access token. See our [iOS Integration Guide](https://smartcar.com/docs/integration-guides/ios/introduction/) for more on this exchange. |
 | `state` | `String` | `nil` | If `state` was provided in the `.launchAuthFlow` method, it will be returned here. |
 
@@ -61,7 +61,7 @@ func completionHandler(err: Error?, code: String?, state: String?) -> Any {
 | --------- | ---- | ------- | ----------- |
 | `state` | `String` | `nil` | An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded. |
 | `forcePrompt` | `Bool` | `false` | The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past. |
-| `vehicleInfo` | `VehicleInfo` | `nil` | Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| `vehicleInfo` | [`VehicleInfo`](#class-vehicleinfo-constructor) | `nil` | Passing in a [`VehicleInfo`](#class-vehicleinfo-constructor) object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 | `viewController` | `UIViewController` | _Required_ | Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
 
 ### Example

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,76 @@
+# Smartcar iOS SDK
+
+Smartcar iOS SDK documentation.
+
+## Class `SmartcarAuth` Constructor
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `clientId` | `String` | _Required_ | Application client ID obtained from [Smartcar Developer Portal](https://developer.smartcar.com/). |
+| `redirectUri` | `String` | _Required_ | Your app must register a custom URI scheme with iOS in order to receive the authorization callback. Smartcar requires the custom URI scheme to be in the format of `"sc" + clientId + "://" + hostname`. This URI must also be registered in [Smartcar's developer portal](https://developer.smartcar.com) for your app. You may append an optional path component or TLD (e.g. `sc4a1b01e5-0497-417c-a30e-6df6ba33ba46://page`). Read here for more information on [configuration of a custom scheme](http://www.idev101.com/code/Objective-C/custom_url_schemes.html). |
+| `scope` | `Array<String>` | `[]` | Permissions requested from the user for specific grant. See the [Smartcar developer documentation](https://smartcar.com/docs/api) for a full list of available permissions. If the `scope` array is empty, all permissions will be requested. |
+| `testMode` | `Bool` | `false` | Set to `true` to launch the Smartcar auth flow in test mode. |
+| `completion` | `Function` | _Required_ | Callback function to be invoked upon completion of the Smartcar Authorization Flow. See the **Completion Handler** section below for details on the function's inputs. |
+
+### Example
+
+```swift
+let smartcar = SmartcarAuth(
+  clientId: "afb0b7d3-807f-4c61-9b04-352e91fe3134",
+  redirectUri: "scafb0b7d3-807f-4c61-9b04-352e91fe3134://page",
+  scope: ["read_vin", "read_vehicle_info", "read_odometer"],
+  completion: completionHandler
+)
+```
+
+## Completion Handler
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `error` | `AuthorizationError` | `nil` | This error will be present if there is a failure in the Smartcar Authorization Flow. Normally, this indicates that a vehicle owner pressed "Deny" to grant your application access to their vehicle. |
+| `code` | `String` | `nil` | Received upon successful authorization. This code should be used to exchange with Smartcar for a long lasting access token. See our [iOS Integration Guide](https://smartcar.com/docs/integration-guides/ios/introduction/) for more on this exchange. |
+| `state` | `String` | `nil` | If `state` was provided in the `.launchAuthFlow` method, it will be returned here. |
+
+### Example
+
+```swift
+func completionHandler(err: Error?, code: String?, state: String?) -> Any {
+  // Receive authorization code
+}
+```
+
+## Method `.launchAuthFlow`
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `state` | `String` | `nil` | An opaque value used by the client to maintain state between the request and the callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery attempts. Smartcar supports all `state` strings that can be url-encoded. |
+| `forcePrompt` | `Bool` | `false` | The `false` option will skip the approval prompt for users who have already accepted the requested permissions for your application in the past. Set to `true` to force a user to see the approval prompt even if they have already accepted the permissions in the past. |
+| `vehicleInfo` | `VehicleInfo` | `nil` | Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+| `viewController` | `UIViewController` | _Required_ | Passing in a `VehicleInfo` object with a `make` property causes the OEM selector screen to be bypassed, allowing the user to go directly to the specific brand vehicle login screen. For a complete list of supported makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+
+### Example
+
+```swift
+smartcar.launchAuthFlow(viewController: self)
+```
+
+## Class `VehicleInfo` Constructor
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `make` | String | `nil` | Including a `make` on the optional `VehicleInfo` object allows users to bypass the car brand selection screen. For a complete list of compabible makes, please see our [API Reference](https://smartcar.com/docs/api#authorization) documentation. |
+
+### Example
+
+```swift
+// Launch authorization flow directly to the Tesla login screen
+smartcar.launchAuthFlow(vehicleInfo: VehicleInfo(make: "Tesla"), viewController: self)
+```
+
+## Enum `AuthorizationError`
+
+| Case | Description | 
+| ---- | ----------- |
+| `accessDenied` | The vehicle owner denied your application access to their vehicle. This case is common and should be handled. |
+| `missingQueryParameters` | The redirect callback was recieved with no query parameters. This is unexpected and should not occur in normal operation. |
+| `missingAuthCode` | The redirect callback was recieved with some query parameters, but neither a `code` nor an `error` was present. This is unexpected and should not occur in normal operation. |

--- a/doc/README.md
+++ b/doc/README.md
@@ -44,7 +44,7 @@ let smartcar = SmartcarAuth(
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
 | `error` | [`AuthorizationError`](#enum-authorizationerror) | `nil` | This error will be present if there is a failure in the Smartcar Authorization Flow. Normally, this indicates that a vehicle owner pressed "Deny" to grant your application access to their vehicle. |
-| `code` | `String` | `nil` | Received upon successful authorization. This code should be used to exchange with Smartcar for a long lasting access token. See our [iOS Integration Guide](https://smartcar.com/docs/integration-guides/ios/introduction/) for more on this exchange. |
+| `code` | `String` | `nil` | Received upon successful authorization. This code should be used to exchange with Smartcar for a long-lasting access token. See our [iOS Integration Guide](https://smartcar.com/docs/integration-guides/ios/introduction/) for more on this exchange. |
 | `state` | `String` | `nil` | If `state` was provided in the `.launchAuthFlow` method, it will be returned here. |
 
 ### Example
@@ -88,5 +88,5 @@ smartcar.launchAuthFlow(vehicleInfo: VehicleInfo(make: "Tesla"), viewController:
 | Case | Description | 
 | ---- | ----------- |
 | `accessDenied` | The vehicle owner denied your application access to their vehicle. This case is common and should be handled. |
-| `missingQueryParameters` | The redirect callback was recieved with no query parameters. This is unexpected and should not occur in normal operation. |
-| `missingAuthCode` | The redirect callback was recieved with some query parameters, but neither a `code` nor an `error` was present. This is unexpected and should not occur in normal operation. |
+| `missingQueryParameters` | The redirect callback was received with no query parameters. This is unexpected and should not occur in normal operation. |
+| `missingAuthCode` | The redirect callback was received with some query parameters, but neither a `code` nor an `error` was present. This is unexpected and should not occur in normal operation. |

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,6 +2,22 @@
 
 Smartcar iOS SDK documentation.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Class `SmartcarAuth` Constructor](#class-smartcarauth-constructor)
+  - [Example](#example)
+- [Completion Handler](#completion-handler)
+  - [Example](#example-1)
+- [Method `.launchAuthFlow`](#method-launchauthflow)
+  - [Example](#example-2)
+- [Class `VehicleInfo` Constructor](#class-vehicleinfo-constructor)
+  - [Example](#example-3)
+- [Enum `AuthorizationError`](#enum-authorizationerror)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Class `SmartcarAuth` Constructor
 
 | Parameter | Type | Default | Description |


### PR DESCRIPTION
This PR started to address #52 which pointed out the lack of documentation around errors returned to the completion handler in the SDK. The PR expanded to re-format the documentation into a nicer tabular format and split the class and method reference into a separate file which is easier to read and navigate.

It is best reviewed by looking at the READMEs in the rendered view:
- [README.md](https://github.com/smartcar/ios-sdk/blob/error-documentation/README.md)
- [SDK Reference](https://github.com/smartcar/ios-sdk/blob/error-documentation/doc/README.md)