### PR TITLE
Access level of AuthorizationError variables and inner ErrorType enum were updated

### DIFF
--- a/SmartcarAuth.podspec
+++ b/SmartcarAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmartcarAuth'
-  s.version          = '4.1.0'
+  s.version          = '4.1.1'
   s.summary          = 'Smartcar Authentication SDK for iOS written in Swift 5.'
 
   s.description      = <<-DESC

--- a/SmartcarAuth/AuthorizationError.swift
+++ b/SmartcarAuth/AuthorizationError.swift
@@ -24,7 +24,7 @@
 * Error that gets created when the authorization flow exits with an error.
 */
 @objc public class AuthorizationError: NSObject, Error {
-    enum ErrorType {
+    public enum ErrorType {
         case missingQueryParameters
         case missingAuthCode
         case accessDenied
@@ -34,8 +34,8 @@
         case unknownError
     }
     
-    var type: ErrorType
-    var errorDescription: String?
+    public let type: ErrorType
+    public let errorDescription: String?
     var vehicleInfo: VehicleInfo?
     
     init(type: ErrorType, errorDescription: String? = nil, vehicleInfo: VehicleInfo? = nil) {

--- a/docs/Classes.html
+++ b/docs/Classes.html
@@ -17,7 +17,7 @@
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/Classes/SCUrlBuilder.html
+++ b/docs/Classes/SCUrlBuilder.html
@@ -17,7 +17,7 @@
     <a title="SCUrlBuilder Class Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="../index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="../index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="../search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/Classes/SmartcarAuth.html
+++ b/docs/Classes/SmartcarAuth.html
@@ -17,7 +17,7 @@
     <a title="SmartcarAuth Class Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="../index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="../index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="../search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/Classes/VehicleInfo.html
+++ b/docs/Classes/VehicleInfo.html
@@ -17,7 +17,7 @@
     <a title="VehicleInfo Class Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="../index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="../index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="../search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes.html
+++ b/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes.html
@@ -17,7 +17,7 @@
     <a title="Classes  Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes/SCURLBuilder.html
+++ b/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes/SCURLBuilder.html
@@ -17,7 +17,7 @@
     <a title="SCUrlBuilder Class Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="../index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="../index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="../search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes/SmartcarAuth.html
+++ b/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes/SmartcarAuth.html
@@ -17,7 +17,7 @@
     <a title="SmartcarAuth Class Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="../index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="../index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="../search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes/VehicleInfo.html
+++ b/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/Classes/VehicleInfo.html
@@ -17,7 +17,7 @@
     <a title="VehicleInfo Class Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="../index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="../index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="../search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/index.html
+++ b/docs/docsets/SmartcarAuth.docset/Contents/Resources/Documents/index.html
@@ -16,7 +16,7 @@
     <a title="SmartcarAuth  Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
     <a title="SmartcarAuth  Reference"></a>
     <header>
       <div class="content-wrapper">
-        <p><a href="index.html">SmartcarAuth 4.1.0 Docs</a> (100% documented)</p>
+        <p><a href="index.html">SmartcarAuth 4.1.1 Docs</a> (100% documented)</p>
         <p class="header-right">
           <form role="search" action="search.json">
             <input type="text" placeholder="Search documentation" data-typeahead>


### PR DESCRIPTION
This is a tiny PR with the main purpose to close [this](https://github.com/smartcar/ios-sdk/issues/62) issue.

Access levels of `type`, `errorDescription` and enum `ErrorType` were updated so now we can use it outside of the SDK.