### PR TITLE
fix: remove spacing at the top of WebView

### DIFF
--- a/SmartcarAuth.podspec
+++ b/SmartcarAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmartcarAuth'
-  s.version          = '6.1.4'
+  s.version          = '6.1.5'
   s.summary          = 'Smartcar Authentication SDK for iOS written in Swift 5.'
 
   s.description      = <<-DESC

--- a/SmartcarAuth/OauthCapture.swift
+++ b/SmartcarAuth/OauthCapture.swift
@@ -54,7 +54,7 @@ import AuthenticationServices
         
         let webviewConfiguration = WKWebViewConfiguration()
         webviewConfiguration.userContentController.add(self, name: "SmartcarSDK")
-        self.webView = WKWebView(frame: CGRect(x: 0, y:50, width: Int((viewController.view.frame.width)), height: Int((viewController.view.frame.height))), configuration: webviewConfiguration)
+        self.webView = WKWebView(frame: CGRect(x: 0, y:0, width: Int((viewController.view.frame.width)), height: Int((viewController.view.frame.height))), configuration: webviewConfiguration)
         self.webView.scrollView.contentInsetAdjustmentBehavior = .never
         self.webView.navigationDelegate = self
         


### PR DESCRIPTION
Removing spacing at the top of WebView so that extends to the full height of the screen

See screenshots in coordinated PR: https://github.com/smartcar/connect-frontend/pull/262