### PR TITLE
Add support for Swift Package Manager (SPM)

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "SmartcarAuth",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "SmartcarAuth",
+            targets: ["SmartcarAuth"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.7.1")
+    ],
+    targets: [
+        .target(
+            name: "SmartcarAuth",
+            path: "SmartcarAuth",
+            exclude: [],
+            resources: [],
+            swiftSettings: []
+        ),
+        .testTarget(
+            name: "SmartcarAuthTests",
+            dependencies: [
+                "SmartcarAuth",
+                .product(name: "Nimble", package: "Nimble")
+            ],
+            path: "SmartcarAuthTests"
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/SmartcarAuth/AuthorizationError.swift
+++ b/SmartcarAuth/AuthorizationError.swift
@@ -20,6 +20,8 @@
  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import Foundation
+
 /**
 * Error that gets created when the authorization flow exits with an error.
 */

--- a/SmartcarAuth/RPCInterface.swift
+++ b/SmartcarAuth/RPCInterface.swift
@@ -20,6 +20,8 @@
  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import Foundation
+
 struct RPCRequestObjectParams: Codable {
     var authorizeURL: String
     var interceptPrefix: String

--- a/SmartcarAuth/SCUrlBuilder.swift
+++ b/SmartcarAuth/SCUrlBuilder.swift
@@ -17,6 +17,8 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+import Foundation
+
 /**
 * A builder used for generating Smartcar Connect authorization URLs.
 * Use the built string with `SmartcarAuth.launchAuthFlow(...)

--- a/SmartcarAuth/VehicleInfo.swift
+++ b/SmartcarAuth/VehicleInfo.swift
@@ -20,6 +20,8 @@
  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import Foundation
+
 /**
  VehicleInfo class is used to describe the vehicle information that may be returned via query parameters in the case of authentication failure.
  */


### PR DESCRIPTION
### Motivation and Context
This PR adds support for Swift Package Manager (SPM) to the SmartCar SDK, which currently only supports CocoaPods. It addresses the issue https://github.com/smartcar/ios-sdk/issues/60, where SPM support was requested to make the SDK easier to integrate without relying on CocoaPods.

### Description
To enable Swift Package Manager support, I made the following changes:
- Create a Package.swift file based on the existing .podspec to define the module and its dependencies (e623b32)
- Open the Package.swift in Xcode to generate the necessary SPM files (9c7ba9f)
- Add Foundation imports where needed to make sure everything compiles correctly with SPM (9dbbe77)

Some things I considered:
- I chose not to alter the existing folder structure to avoid disrupting the current CocoaPods setup.
- The CocoaPods configuration remains unchanged and continues to work as expected.
- All tests pass if executed from the SPM package, as shown in the screenshot below.

### Testing Steps
You can test this PR in two ways:
1. Open the Package.swift in Xcode, build the main scheme, and run the tests.
2. Try out the [sample app](https://github.com/user-attachments/files/20395392/SmartCar.iOS.SPM.integration.zip) I’ve attached, which is already set up to use the SDK via SPM.

### Results

<details>
<summary>Using the SDK as a Swift package</summary>

<img width="1289" alt="Smart Car SPM package" src="https://github.com/user-attachments/assets/583d1b34-7673-497a-ace8-20309ef0e87d" />

</details>

<details>
<summary> Integrating the SDK as an SPM package in a sample iOS app</summary>

<img width="1289" alt="Smart Car SPM package" src="https://github.com/user-attachments/assets/583d1b34-7673-497a-ace8-20309ef0e87d" />

</details>

